### PR TITLE
Change the way we build the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY . /app
 RUN CGO_ENABLED=0 GOOS=linux go build -o /go-app 
 
 # This stage will be our final image to be used on the cluster - With a multi-stage build approach we reduce the number of layers and the final image size
-FROM alpine:edge
+FROM scratch
 
 WORKDIR /app
 COPY --from=build_base /go-app .


### PR DESCRIPTION
- Changed the Dockerfile to use a multi-stage build approach, so the resulting image will have only our binary
- Don't use a specific base image on the final image (using `FROM scratch`), it helps to reduce your attack surface and keep the image small
- Added `ENV` definitions on the second stage, with that you can pass any needed variables to the application be able to reach the PSQL instance
- Renamed the binary from `main` to `go-app` (`main` assumes you will have other stuff in the image, which are not the case here.
- The image tag now is passed through an build argument `GO_VERSION`, during your local builds, pass it with: `docker build -t <your image tag> --build-arg GO_VERSION="<desired go version here>" -f Dockerfile .`